### PR TITLE
Configure CALM Levels to Info

### DIFF
--- a/mta.yaml
+++ b/mta.yaml
@@ -7,8 +7,8 @@ modules:
     type: nodejs
     path: gen/srv
     properties:
-      SAP_CALM_FESR_LOG_LEVEL: debug
-      SAP_CALM_DCI_LOG_LEVEL: debug
+      SAP_CALM_FESR_LOG_LEVEL: info
+      SAP_CALM_DCI_LOG_LEVEL: info
       SAP_CALM_SERVICE_NAME: incident-management-srv
       SAP_CALM_SERVICE_TYPE: SAP_CP_CF
       SAP_CALM_DCI_AGG_THRESHOLD: 10


### PR DESCRIPTION
**Problem**

Some logs are dropped out when debug log levels are turned on. As a result, Application Autoscaler does not get expected metrics from the CF logging system (log-cache)


**Solution**

Set the following log levels to INFO

```
 SAP_CALM_FESR_LOG_LEVEL: info
 SAP_CALM_DCI_LOG_LEVEL: info
```
